### PR TITLE
Fixed Cypress run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,3 @@ I also gave a try to the new fancy [Github Actions](https://github.com/features/
 - Validate input fields
 - Use some fixtures for E2E tests
 - Probably I am forgetting a bunch of them :-)
-
-### Note
-
-There is a problem running Cypress using `cypress run`, it might be related to https://github.com/cypress-io/cypress/issues/2069.
-For the moment, in order to run the integration tests, run `cypress open` and then _run all specs_

--- a/cypress/integration/happy_spec.js
+++ b/cypress/integration/happy_spec.js
@@ -9,7 +9,7 @@ describe('The Web App', function() {
     cy.get('form')
       .first()
       .submit();
-    cy.get('tr')
+    cy.get('tbody tr')
       .first()
       .contains('1.1');
   });
@@ -26,7 +26,7 @@ describe('The Web App', function() {
       .submit();
     cy.contains('Not found!');
 
-    cy.get('div > :nth-child(3)').click();
+    cy.get('div > button:nth-child(3)').click();
     cy.get('table');
   });
 });

--- a/package.json
+++ b/package.json
@@ -22,14 +22,17 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest-fetch-mock": "^2.1.2",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "start-server-and-test": "^1.10.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "lint": "eslint src --ext .jsx,.js",
     "unit": "react-scripts test",
-    "test": "npm run lint && npm run unit",
+    "integration": "start-server-and-test start http://localhost:3000 cy:run",
+    "test": "npm run lint && npm run unit && npm run integration",
+    "cy:run": "cypress run --browser chrome",
     "eject": "react-scripts eject"
   },
   "browserslist": {


### PR DESCRIPTION
Fixed `cypress run` forcing	the test to be run using _Chrome_.

By default `cypress` runs _Electron_ and the version currently used is not supporting a bunch of new ES functionalities (i.e. spread operator), see https://github.com/cypress-io/cypress/issues/2069 for more details.